### PR TITLE
PR template and GitHub primeicon in footer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## This PR Closes Issue
+
+closes #
+
+## Description
+
+## What type of PR is this? (check all applicable)
+
+- [ ] ✨ Feature
+- [ ] 🐛 Bug Fix
+- [ ] 📝 Documentation Update
+- [ ] 🎨 Style
+- [ ] 🧑‍💻 Code Refactor
+- [ ] 🔥 Performance Improvements
+- [ ] ✅ Test
+- [ ] 🤖 Build
+- [ ] 🔁 CI
+- [ ] 📦 Chore (Release)
+- [ ] ⏩ Revert
+
+## Mobile & Desktop Screenshots/Recordings
+
+[Attach screenshots or recordings if applicable]
+
+## Steps to QA
+
+## Added to documentation?
+
+- [ ] 📜 README.md
+- [ ] 🙅 no documentation needed
+
+## [Optional] Post-deployment tasks
+
+[Specify any post-deployment tasks that need to be performed]
+
+## [Optional] What gif best describes this PR or how it makes you feel?
+
+[Embed gif or describe the feeling in plain text]

--- a/pdf/src/app/shared/components/footer/footer.component.ts
+++ b/pdf/src/app/shared/components/footer/footer.component.ts
@@ -12,8 +12,8 @@ import { Component } from '@angular/core'
         href="https://github.com/dalenguyen/pdfun"
         class="underline"
         target="_blank"
-        >Github</a
-      >
+        ><i class="pi pi-github" style="font-size: 1.5rem"></i
+      ></a>
     </footer>
   `,
 })


### PR DESCRIPTION
closes #4 

- added one of the PR templates hat I have been using for my Open Source projects (which originates from Open Sauced and I think it's very cool)
- added primeicon in footer for GitHub

> Note

- a bit of a new app setup for me, first time I used Nx cloud - I did all the required setup to avoid the error, but I was not able to run the project locally I just got a blank page on `http://localhost:4200/` I know there is something more that I am missing with the setup but could not figure out what it was, possibly `firebase` related something 

- anyways the only reason I am mentioning this is because I could not see what the prime icon looks like in the browser, I hope it's ok 

